### PR TITLE
Edit Specialist Dashboard to show a list of ideas

### DIFF
--- a/src/components/SpecialistPortal/Dashboard/SpecialistDashboard.js
+++ b/src/components/SpecialistPortal/Dashboard/SpecialistDashboard.js
@@ -4,13 +4,18 @@ import { baseUrl } from "../../../constants";
 import { Redirect, Link } from "react-router-dom";
 import "./SpecialistDashboard.css";
 import mentor from "../../../res/mentor.png";
+import styled from "@emotion/styled";
+import Card from "@material-ui/core/Card";
 // import assess from '../../../res/assess-white.png'
 // import invest from '../../../res/invest-white.png'
 
 // import crowdfunding from '../../../res/crowdfunding.png'
 
 export default function specialistDashboard(props) {
-  const [userData, setUserData] = useState({});
+  const [userData, setUserData] = useState({
+    specialistType: "Not a specialist",
+  });
+  const [ideaList, setIdeaList] = useState(false);
   const [userLoggedIn, setUserLoggedIn] = useState(true);
 
   useEffect(() => {
@@ -26,8 +31,16 @@ export default function specialistDashboard(props) {
     props.user();
   }
 
+  useEffect(() => {
+    request
+      .get(`${baseUrl}/ideas/specialist`)
+      .set("Authorization", `Bearer ${props.authState.token}`)
+      .then((res) => setIdeaList(res.body));
+  }, []);
+
   if (userLoggedIn === false) return <Redirect to="/Specialist/login" />;
 
+  //this below should go in new ADMIN dashboard
   const showNewSpecialist =
     props.authState.user.role === "admin" ? (
       <Link className="links" to="/Admin/dashboard/newspecialist">
@@ -38,10 +51,196 @@ export default function specialistDashboard(props) {
       </Link>
     ) : null;
 
+  const renderTitle =
+    userData && props.authState.user ? (
+      <h2 className="title">
+        {userData.firstName}'s{" "}
+        {props.authState.user.specialistType.charAt(0).toUpperCase() +
+          props.authState.user.specialistType.slice(1)}{" "}
+        Specialist Dashboard
+      </h2>
+    ) : null;
+
+  const renderIdeaList = () => {
+    if (ideaList.length < 1) {
+      return (
+        <h2 style={styledH2}>
+          There are no idea's available in your relevant phase(s)
+        </h2>
+      );
+    }
+    if (props.authState.user.specialistType === "patent") {
+      const render4 = ideaList.ideasPhase4.map((idea) => (
+        <Link
+          key={idea.id}
+          className="tile-link"
+          to={`/specialist/dashboard/${idea.id}`}
+        >
+          <div className="assess-tile" key={idea.id}>
+            <p style={{ color: "black" }}>
+              <b>Title: </b>
+              <br />
+              {idea.idea[5].answers[0].qAnswer}
+            </p>
+            <br />
+            <p style={{ color: "black" }}>
+              <b>Description: </b>
+              <br />
+              {idea.idea[5].answers[1].qAnswer}
+            </p>
+            <br />
+          </div>
+        </Link>
+      ));
+      const card = renderCard("patent2");
+      const render6 = ideaList.ideasPhase4.map((idea) => (
+        <Link
+          key={idea.id}
+          className="tile-link"
+          to={`/specialist/dashboard/${idea.id}`}
+        >
+          <div className="assess-tile" key={idea.id}>
+            <p style={{ color: "black" }}>
+              <b>Title: </b>
+              <br />
+              {idea.idea[5].answers[0].qAnswer}
+            </p>
+            <br />
+            <p style={{ color: "black" }}>
+              <b>Description: </b>
+              <br />
+              {idea.idea[5].answers[1].qAnswer}
+            </p>
+            <br />
+          </div>
+        </Link>
+      ));
+      if (ideaList.ideasPhase4.length < 1 && ideaList.ideasPhase6.length < 1) {
+        return (
+          <>
+            {renderCard(props.authState.user.specialistType)}
+            <div className="flex-tilescontainer">
+              <h2 style={styledH2}>
+                There are no idea's available in your relevant phase
+              </h2>
+            </div>{" "}
+            {card}
+            <div className="flex-tilescontainer">
+              <h2 style={styledH2}>
+                There are no idea's available in your relevant phase
+              </h2>
+            </div>
+          </>
+        );
+      }
+      if (ideaList.ideasPhase4.length < 1 && ideaList.ideasPhase6.length >= 1) {
+        return (
+          <>
+            {renderCard(props.authState.user.specialistType)}
+            <div className="flex-tilescontainer">
+              <h2 style={styledH2}>
+                There are no idea's available in your relevant phase
+              </h2>
+            </div>
+
+            {card}
+            <div className="flex-tilescontainer">{render6}</div>
+          </>
+        );
+      }
+      if (ideaList.ideasPhase4.length >= 1 && ideaList.ideasPhase6.length < 1) {
+        return (
+          <>
+            {renderCard(props.authState.user.specialistType)}
+            <div className="flex-tilescontainer">{render4}</div>
+
+            {card}
+            <div className="flex-tilescontainer">
+              <h2 style={styledH2}>
+                There are no idea's available in your relevant phase
+              </h2>
+            </div>
+          </>
+        );
+      } else
+        return (
+          <>
+            {renderCard(props.authState.user.specialistType)}
+            <div className="flex-tilescontainer">{render4}</div>
+
+            {card}
+            <div className="flex-tilescontainer">{render6}</div>
+          </>
+        );
+    } else
+      return ideaList.map((idea) => (
+        <div className="flex-tilescontainer">
+          {props.authState.user.role === "admin"
+            ? null
+            : renderCard(props.authState.user.specialistType)}
+          <Link
+            key={idea.id}
+            className="tile-link"
+            to={`/specialist/dashboard/${idea.id}`}
+          >
+            <div className="assess-tile" key={idea.id}>
+              <p style={{ color: "black" }}>
+                <b>Title: </b>
+                <br />
+                {idea.idea[5].answers[0].qAnswer}
+              </p>
+              <br />
+              <p style={{ color: "black" }}>
+                <b>Description: </b>
+                <br />
+                {idea.idea[5].answers[1].qAnswer}
+              </p>
+              <br />
+            </div>
+          </Link>
+        </div>
+      ));
+  };
+
+  function specialistPhase(type) {
+    if (type === "patent") return "4";
+    if (type === "patent2") return "6";
+    if (type === "validation") return "5";
+    if (type === "calculation" || type === "subsidy") return "7";
+  }
+  const renderCard = (type) => {
+    if (!props.authState.user) return null;
+    else
+      return (
+        <StyledCard>
+          Here are the ideas that are currently in phase {specialistPhase(type)}
+          .<p>You can view and edit the ideas.</p>
+        </StyledCard>
+      );
+  };
+
   return (
     <div className="dashboard-container">
-      <h2 className="title">{userData.firstName}'s specialist dashboard</h2>
+      {renderTitle}
       <div className="flex-tilescontainer">{showNewSpecialist}</div>
+
+      {ideaList ? renderIdeaList() : null}
     </div>
   );
 }
+
+const styledH2 = {
+  fontSize: 20,
+  fontWeight: 400,
+  color: "white",
+};
+
+const StyledCard = styled(Card)`
+  background-color: rgb(255, 255, 255, 0.3);
+  padding: 50px;
+  width: 500px;
+  margin: auto;
+  color: white;
+  display: flex;
+  flex-direction: column;
+`;


### PR DESCRIPTION
This adds functionality to the Specialist Dashboard.
It now shows a list of ideas based on the type of specialist
For example **Patent Specialist** gets two list of idea's that are in phase 4 and phase 6
For example **Validation Specialist** gets one list of idea's that are in phase 5
If there are no idea's in the specialists list, then it show that there are no ideas

![Peek 2020-06-18 15-57](https://user-images.githubusercontent.com/15126539/85029431-901b7100-b17c-11ea-93ed-46a333d1b4ad.gif)

