### PR TITLE
Feat fix ticket 11 - Validate the number of words describing an idea

### DIFF
--- a/src/components/MyIdea/IdeaSubmission/idea-form-v1.json
+++ b/src/components/MyIdea/IdeaSubmission/idea-form-v1.json
@@ -633,7 +633,6 @@
         "text": "Describe your idea in up to 3 words *",
         "validationRegex": "^(?:[A-Za-z,]+ ){0,2}[A-Za-z]+$",
         "maxChar": 150,
-        "maxWords": 3,
         "validationErrorMsg": "Please separate the words by commas or spaces only, and number of words cannot be more than 3 words."
       },
       {

--- a/src/components/MyIdea/IdeaSubmission/idea-form-v1.json
+++ b/src/components/MyIdea/IdeaSubmission/idea-form-v1.json
@@ -633,7 +633,8 @@
         "text": "Describe your idea in up to 3 words *",
         "validationRegex": "^(?:[A-Za-z,]+ ){0,2}[A-Za-z]+$",
         "maxChar": 150,
-        "validationErrorMsg": "Please separate the words by commas or spaces only."
+        "maxWords": 3,
+        "validationErrorMsg": "Please separate the words by commas or spaces only, and number of words cannot be more than 3 words."
       },
       {
         "id": 1,

--- a/src/components/reogranisation/Questions/QuestionGroup.js
+++ b/src/components/reogranisation/Questions/QuestionGroup.js
@@ -98,6 +98,7 @@ const QuestionGroup = (props) => {
                     questionTitle={question.text}
                     errorMessage={question.validationErrorMsg}
                     maxChar={question.maxChar}
+                    maxWords={question.maxWords}
                     onChange={handleValueChanges}
                     onFocusChanged={handleInputFocus}
                     id={question.id.toString()}

--- a/src/components/reogranisation/Questions/QuestionGroup.js
+++ b/src/components/reogranisation/Questions/QuestionGroup.js
@@ -98,9 +98,9 @@ const QuestionGroup = (props) => {
                     questionTitle={question.text}
                     errorMessage={question.validationErrorMsg}
                     maxChar={question.maxChar}
-                    maxWords={question.maxWords}
                     onChange={handleValueChanges}
                     onFocusChanged={handleInputFocus}
+                    groupId={props.group.id}
                     id={question.id.toString()}
                     onValidationChange={handleValidationChanges}
                     placeholder={

--- a/src/components/reogranisation/Questions/SingleLineQuestion.js
+++ b/src/components/reogranisation/Questions/SingleLineQuestion.js
@@ -10,12 +10,25 @@ const SingleLineQuestion = (props) => {
   const [isStillInit, setIsStillInit] = useState(true);
   const [validated, setValidated] = useState(false);
   const [currentValue, setCurrentValue] = useState("");
+  const [errors, setErrors] = useState(false);
 
   useEffect(() => {
     props.onValidationChange && props.onValidationChange(props.id, validated);
   }, [validated]);
 
   useEffect(() => {
+    if (props.maxWords) {
+      const replaceComma = currentValue.trim().replace(/,/g, " ");
+      const removeSpaces = replaceComma.replace(/\s\s+/g, " ");
+      const splitBySpace = removeSpaces.trim().split(" ");
+      const numOfWords = splitBySpace.length;
+      if (numOfWords > props.maxWords) {
+        setErrors(true);
+      } else {
+        setErrors(false);
+      }
+    }
+
     if (currentValue.length > 1 && currentValue.length < props.maxChar) {
       setValidated(true);
     } else {
@@ -81,7 +94,7 @@ const SingleLineQuestion = (props) => {
       )}
       <ErrorMessage
         pose={
-          !isStillInit && !!props.validationRegex && !validated
+          (!isStillInit && !!props.validationRegex && !validated) || errors
             ? "show"
             : "hide"
         }

--- a/src/components/reogranisation/Questions/SingleLineQuestion.js
+++ b/src/components/reogranisation/Questions/SingleLineQuestion.js
@@ -10,27 +10,26 @@ const SingleLineQuestion = (props) => {
   const [isStillInit, setIsStillInit] = useState(true);
   const [validated, setValidated] = useState(false);
   const [currentValue, setCurrentValue] = useState("");
-  const [errors, setErrors] = useState(false);
 
   useEffect(() => {
     props.onValidationChange && props.onValidationChange(props.id, validated);
   }, [validated]);
 
   useEffect(() => {
-    if (props.maxWords) {
-      const replaceComma = currentValue.trim().replace(/,/g, " ");
-      const removeSpaces = replaceComma.replace(/\s\s+/g, " ");
-      const splitBySpace = removeSpaces.trim().split(" ");
-      const numOfWords = splitBySpace.length;
-      if (numOfWords > props.maxWords) {
-        setErrors(true);
-      } else {
-        setErrors(false);
-      }
-    }
-
     if (currentValue.length > 1 && currentValue.length < props.maxChar) {
-      setValidated(true);
+      if (props.maxWords) {
+        const replaceComma = currentValue.trim().replace(/,/g, " ");
+        const removeSpaces = replaceComma.replace(/\s\s+/g, " ");
+        const splitBySpace = removeSpaces.trim().split(" ");
+        const numOfWords = splitBySpace.length;
+        if (numOfWords <= props.maxWords) {
+          setValidated(true);
+        } else {
+          setValidated(false);
+        }
+      } else {
+        setValidated(true);
+      }
     } else {
       setValidated(false);
     }
@@ -94,7 +93,7 @@ const SingleLineQuestion = (props) => {
       )}
       <ErrorMessage
         pose={
-          (!isStillInit && !!props.validationRegex && !validated) || errors
+          !isStillInit && !!props.validationRegex && !validated
             ? "show"
             : "hide"
         }

--- a/src/components/reogranisation/Questions/SingleLineQuestion.js
+++ b/src/components/reogranisation/Questions/SingleLineQuestion.js
@@ -17,12 +17,12 @@ const SingleLineQuestion = (props) => {
 
   useEffect(() => {
     if (currentValue.length > 1 && currentValue.length < props.maxChar) {
-      if (props.maxWords) {
+      if (props.groupId === 5 && parseInt(props.id) === 0) {
         const replaceComma = currentValue.trim().replace(/,/g, " ");
         const removeSpaces = replaceComma.replace(/\s\s+/g, " ");
         const splitBySpace = removeSpaces.trim().split(" ");
         const numOfWords = splitBySpace.length;
-        if (numOfWords <= props.maxWords) {
+        if (numOfWords <= 3) {
           setValidated(true);
         } else {
           setValidated(false);


### PR DESCRIPTION
## Validate the number of words describing an idea 

**Issue:** On the idea-form there is a question that says ‘Describe your idea in up to 3 words *:’. The user can add more than 3 words.

**Solution:** 
1. Changed the error message text from "Please separate the words by commas or spaces only." to "Please separate the words by commas or spaces only, and number of words cannot be more than 3 words."
2. Pass groupId and question Id as props to the component.
3. Perform validation only for question groupId=5 and questionId=0.
4. Validation Logic: 
     - Replace all commas from the input string with spaces
     - Replace multiple spaces with a single space.
     - Split the modified string by space 
     - Count the number of words in the split string and validate.
     