### PR TITLE
Change of Routes

### DIFF
--- a/src/components/SpecialistPortal/SpecialistCreation/SpecialistRegistration.js
+++ b/src/components/SpecialistPortal/SpecialistCreation/SpecialistRegistration.js
@@ -180,7 +180,7 @@ const SpecialistRegistration = (props) => {
       specialistType,
     } = formData;
     request
-      .post(`${baseUrl}/users/specialists`)
+      .post(`${baseUrl}/users`)
       .set("Authorization", `Bearer ${props.props.authState.token}`)
       .send({
         firstName: firstName.value,


### PR DESCRIPTION
**Admin Adding Specialist was Broken**
This was due to no router being present for **/users/specialists**. I also saw that the specialists will get funneled into the **users table** regardless. 
So I made the request to **/users** and this handles and works efficiently.
 