### PR TITLE
Validations (minimum number of characters) on the idea submission form questions.

### DIFF
--- a/src/components/MyIdea/Dashboard/AutoMatch.js
+++ b/src/components/MyIdea/Dashboard/AutoMatch.js
@@ -509,7 +509,10 @@ export default function IdeaDashboardDetail(props) {
                     </Heading>
                     <Paragraph>
                       <h2>
-                        {`Your idea did not match with any of the existing data, this is because the ipscreener couldn't make any sense of your idea.`}
+                        {`Unfortunately, the information you supplied about your idea on the idea-form was too brief.
+Because of this, we are not able to look for matching patents and can’t continue your idea.
+Please re-submit your idea with a more extensive explanation on what your idea exactly is.
+If you have any questions, please contact us at any time at support@the-idealists.com`}
                       </h2>
                     </Paragraph>
                   </StartContent>

--- a/src/components/MyIdea/Dashboard/AutoMatch.js
+++ b/src/components/MyIdea/Dashboard/AutoMatch.js
@@ -505,7 +505,7 @@ export default function IdeaDashboardDetail(props) {
                         }
                       `}
                     >
-                      Automatch results
+                      First patent check
                     </Heading>
                     <Paragraph>
                       <h2>

--- a/src/components/MyIdea/IdeaSubmission/idea-form-v1.json
+++ b/src/components/MyIdea/IdeaSubmission/idea-form-v1.json
@@ -638,7 +638,7 @@
       {
         "id": 1,
         "type": "singleLine",
-        "text": "Describe your idea in up to 150 characters *",
+        "text": "Describe your idea in up to 150 characters * (minimum of 75 characters)",
         "validationRegex": "^(.){0,150}$",
         "maxChar": 150,
         "validationErrorMsg": "Invalid number of characters."
@@ -654,7 +654,7 @@
       {
         "id": 0,
         "type": "multiLine",
-        "text": "Describe your idea up to 1500 characters *",
+        "text": "Describe your idea up to 1500 characters * (minimum of 500 characters)",
         "validationRegex": "^(*.){1,1500}$",
         "maxChar": 1500,
         "validationErrorMsg": "Max 100 chars."

--- a/src/components/reogranisation/Questions/QuestionGroup.js
+++ b/src/components/reogranisation/Questions/QuestionGroup.js
@@ -115,6 +115,7 @@ const QuestionGroup = (props) => {
                     maxChar={question.maxChar}
                     onChange={handleValueChanges}
                     onFocusChanged={handleInputFocus}
+                    groupId={props.group.id}
                     id={question.id.toString()}
                     onValidationChange={handleValidationChanges}
                     multiLine

--- a/src/components/reogranisation/Questions/SingleLineQuestion.js
+++ b/src/components/reogranisation/Questions/SingleLineQuestion.js
@@ -28,7 +28,25 @@ const SingleLineQuestion = (props) => {
           setValidated(false);
         }
       } else {
-        setValidated(true);
+        if (props.groupId === 5 && parseInt(props.id) === 1) {
+          const strWithNoSpaces = currentValue.replace(/ /g, "");
+          if (strWithNoSpaces.length >= 75) {
+            setValidated(true);
+          } else {
+            setValidated(false);
+          }
+        } else {
+          if (props.groupId === 6 && parseInt(props.id) === 0) {
+            const strWithNoSpaces = currentValue.replace(/ /g, "");
+            if (strWithNoSpaces.length >= 500) {
+              setValidated(true);
+            } else {
+              setValidated(false);
+            }
+          } else {
+            setValidated(true);
+          }
+        }
       }
     } else {
       setValidated(false);


### PR DESCRIPTION
## Validations on the idea submission form questions to describe an idea in 150 characters and 1500 characters.

- Change the text that is displayed to the user when ipscreener is not able to process the idea, to:

First patent check
"Unfortunately, the information you supplied about your idea on the idea-form was too brief. Because of this, we are not able to look for matching patents and can’t continue your idea. Please re-submit your idea with a more extensive explanation on what your idea exactly is. If you have any questions, please contact us at any time at support@the-idealists.com".
- Modify the idea submission form question text from "Describe your idea in up to 150 characters *" to "Describe your idea in up to 150 characters * (minimum of 75 characters)"
- Modify the idea submission form question text from "Describe your idea up to 1500 characters *" to "Describe your idea up to 1500 characters * (minimum of 500 characters)"
- Validate for the user to enter a minimum of 75 characters for the question "Describe your idea in up to 150 characters *"
- Validate for the user to enter a minimum of 500 characters for the question "Describe your idea in up to 1500 characters *"